### PR TITLE
Change [{}] to output empty array.

### DIFF
--- a/lib/exjson/generator.ex
+++ b/lib/exjson/generator.ex
@@ -3,6 +3,8 @@ defprotocol ExJSON.Generator do
 end
 
 defimpl ExJSON.Generator, for: Atom do
+  def generate(nil), do: "null"
+
   def generate(atom), do: inspect(atom_to_binary(atom))
 end
 

--- a/lib/exjson/generator.ex
+++ b/lib/exjson/generator.ex
@@ -5,6 +5,9 @@ end
 defimpl ExJSON.Generator, for: Atom do
   def generate(nil), do: "null"
 
+  def generate(true), do: "true"
+  def generate(false), do: "false"
+
   def generate(atom), do: inspect(atom_to_binary(atom))
 end
 

--- a/lib/exjson/generator.ex
+++ b/lib/exjson/generator.ex
@@ -28,7 +28,7 @@ end
 
 defimpl ExJSON.Generator, for: List do
   def generate([]), do: "{}"
-  def generate([{}]), do: "{}"
+  def generate([{}]), do: "[]"
 
   def generate(list) do
     if has_tuple?(list) do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExJSON.Mixfile do
 
   def project do
     [ app: :exjson,
-      version: "0.2.0",
+      version: "0.2.1",
       deps: deps ]
   end
 

--- a/test/exjson_test.exs
+++ b/test/exjson_test.exs
@@ -4,7 +4,7 @@ defmodule ExJSON.TupleTest do
   test :empty_json do
     assert "{}" ==  ExJSON.generate([])
     assert "{}" ==  ExJSON.generate({})
-    assert "{}" ==  ExJSON.generate([{}])
+    assert "[]" ==  ExJSON.generate([{}])
   end
 
   test :atom_to_quoted do

--- a/test/exjson_test.exs
+++ b/test/exjson_test.exs
@@ -7,6 +7,10 @@ defmodule ExJSON.TupleTest do
     assert "[]" ==  ExJSON.generate([{}])
   end
 
+  test :nil do
+    assert "null" ==  ExJSON.generate(nil)
+  end
+
   test :atom_to_quoted do
     assert "\"name\"" ==  ExJSON.generate(:name)
     assert "\"Name\"" ==  ExJSON.generate(:Name)

--- a/test/exjson_test.exs
+++ b/test/exjson_test.exs
@@ -11,6 +11,14 @@ defmodule ExJSON.TupleTest do
     assert "null" ==  ExJSON.generate(nil)
   end
 
+  test :true do
+    assert "true" ==  ExJSON.generate(true)
+  end
+
+  test :false do
+    assert "false" ==  ExJSON.generate(false)
+  end
+
   test :atom_to_quoted do
     assert "\"name\"" ==  ExJSON.generate(:name)
     assert "\"Name\"" ==  ExJSON.generate(:Name)


### PR DESCRIPTION
- Bumped version.
- Ensure that a nil in ExJSON.generate is represented as null in JSON output.