### PR TITLE
update for Elixir 0.13.2-dev

### DIFF
--- a/lib/exjson/generator.ex
+++ b/lib/exjson/generator.ex
@@ -3,7 +3,7 @@ defprotocol ExJSON.Generator do
 end
 
 defimpl ExJSON.Generator, for: Atom do
-  def generate(atom), do: inspect(atom_to_binary(atom))
+  def generate(atom), do: inspect(Atom.to_string(atom))
 end
 
 defimpl ExJSON.Generator, for: BitString do

--- a/lib/exjson/parser.ex
+++ b/lib/exjson/parser.ex
@@ -1,7 +1,7 @@
 defmodule ExJSON.Parser do
 
   def parse(thing, return_type) when is_binary(thing) do
-    parse(List.from_char_data!(thing), return_type)
+    parse(String.to_char_list(thing), return_type)
   end
 
   def parse(thing, return_type) when is_list(thing) do
@@ -15,6 +15,6 @@ defmodule ExJSON.Parser do
   end
 
   defp normalize_parser(return_type) when is_atom(return_type) do
-    binary_to_atom("exjson_" <> atom_to_binary(return_type))
+    String.to_atom("exjson_" <> Atom.to_string(return_type))
   end
 end

--- a/lib/exjson/parser.ex
+++ b/lib/exjson/parser.ex
@@ -1,7 +1,7 @@
 defmodule ExJSON.Parser do
 
   def parse(thing, return_type) when is_binary(thing) do
-    parse(String.to_char_list!(thing), return_type)
+    parse(List.from_char_data!(thing), return_type)
   end
 
   def parse(thing, return_type) when is_list(thing) do

--- a/lib/exjson/scanner.ex
+++ b/lib/exjson/scanner.ex
@@ -1,6 +1,6 @@
 defmodule ExJSON.Scanner do
   def scan(thing) when is_binary(thing) do
-    String.to_char_list!(thing)
+    List.from_char_data!(thing)
   end
 
   def scan(string) do

--- a/lib/exjson/scanner.ex
+++ b/lib/exjson/scanner.ex
@@ -1,6 +1,6 @@
 defmodule ExJSON.Scanner do
   def scan(thing) when is_binary(thing) do
-    List.from_char_data!(thing)
+    String.to_char_list(thing)
   end
 
   def scan(string) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExJSON.Mixfile do
   def project do
     [ app: :exjson,
       version: "0.3.0",
-      elixir: "0.13.2-dev",
+      elixir: "~> 0.14.2",
       description: description,
       package: package,
       deps: deps ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExJSON.Mixfile do
   def project do
     [ app: :exjson,
       version: "0.3.0",
-      elixir: "0.13.0",
+      elixir: "0.13.2-dev",
       description: description,
       package: package,
       deps: deps ]


### PR DESCRIPTION
String.to_char_list!/1 is deprecated in Elixir 0.13.2-dev in favor of List.from_char_data!/1