### PR TITLE
Fixed deprecated code atom_to_binary and binary_to_atom

### DIFF
--- a/lib/exjson/generator.ex
+++ b/lib/exjson/generator.ex
@@ -3,7 +3,7 @@ defprotocol ExJSON.Generator do
 end
 
 defimpl ExJSON.Generator, for: Atom do
-  def generate(atom), do: inspect(atom_to_binary(atom))
+  def generate(atom), do: inspect(:erlang.atom_to_binary(atom))
 end
 
 defimpl ExJSON.Generator, for: BitString do

--- a/lib/exjson/parser.ex
+++ b/lib/exjson/parser.ex
@@ -15,6 +15,6 @@ defmodule ExJSON.Parser do
   end
 
   defp normalize_parser(return_type) when is_atom(return_type) do
-    binary_to_atom("exjson_" <> atom_to_binary(return_type))
+    :erlang.binary_to_atom("exjson_" <> :erlang.atom_to_binary(return_type))
   end
 end


### PR DESCRIPTION
These fixes allow compilation with erlang 17.1 and elixir 0.14.2-dev.

Replaced atom_to_binary and binary_to_atom with their erlang counterparts.